### PR TITLE
Version 8.0 Build 7

### DIFF
--- a/Hasher.sln
+++ b/Hasher.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.7.34202.233
+VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Hasher", "Hasher\Hasher.vbproj", "{CBCA2ED4-D73A-40F2-9BAB-1C1F1A5534A5}"
 EndProject

--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -1390,7 +1390,7 @@ Public Class Form1
 
                                                              MyInvoke(Sub()
                                                                           lblVerifyHashStatus.Text = $"Now processing file ""{New IO.FileInfo(strFileName).Name}""."
-                                                                          UpdateDataGridViewRow(itemOnGUI, item)
+                                                                          UpdateDataGridViewRow(itemOnGUI, item, False)
                                                                       End Sub)
 
                                                              computeStopwatch = Stopwatch.StartNew

--- a/Hasher/My Project/AssemblyInfo.vb
+++ b/Hasher/My Project/AssemblyInfo.vb
@@ -31,4 +31,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("8.0.6.20")>
+<Assembly: AssemblyFileVersion("8.0.7.21")>


### PR DESCRIPTION
Fixed an issue in which the line item in the data grid on the "Verify Saved Hashes" tab turns white with white text while the file is being processed.