### PR TITLE
Version 8.1 Build 2

### DIFF
--- a/Hasher/Benchmark.vb
+++ b/Hasher/Benchmark.vb
@@ -1,9 +1,12 @@
-﻿Public Class Benchmark
+﻿Imports System.Buffers
+
+Public Class Benchmark
     Private workingThread As Threading.Thread
     Private boolBackgroundThreadWorking As Boolean = False
     Private boolClosingWindow As Boolean
     Public shortBufferSize As Short
     Public boolSetBufferSize As Boolean = False
+    Private pool As ArrayPool(Of Byte) = ArrayPool(Of Byte).Shared
 
     Private Sub Benchmark_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Icon = Icon.ExtractAssociatedIcon(Reflection.Assembly.GetExecutingAssembly().Location)
@@ -101,10 +104,10 @@
         End If
     End Sub
 
-    Private Shared Function DoChecksumWithAttachedSubRoutine(strFile As String, ByRef strChecksum As String, subRoutine As [Delegate], intBufferSize As Integer) As Boolean
+    Private Function DoChecksumWithAttachedSubRoutine(strFile As String, ByRef strChecksum As String, subRoutine As [Delegate], intBufferSize As Integer) As Boolean
         Try
             If IO.File.Exists(strFile) Then
-                Dim checksums As New Checksums(subRoutine)
+                Dim checksums As New Checksums(subRoutine, pool)
                 strChecksum = checksums.PerformFileHash(strFile, intBufferSize).Sha256
                 Return True
             Else

--- a/Hasher/Benchmark.vb
+++ b/Hasher/Benchmark.vb
@@ -33,16 +33,16 @@
                                                      Dim percentage As Double
                                                      Dim strChecksum As String = Nothing
                                                      Dim index As Integer = 1
-                                                     Dim subRoutine As [Delegate] = Sub(size As Long, totalBytesRead As Long)
-                                                                                        Try
-                                                                                            Invoke(Sub()
-                                                                                                       percentage = If(totalBytesRead <> 0 And size <> 0, totalBytesRead / size * 100, 0)
-                                                                                                       ProgressBar.Value = percentage
-                                                                                                       lblStatus.Text = $"{strFileNameLine}{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({Math.Round(percentage, byteRoundPercentages)}%) have been processed with a {intBufferSize} MB buffer size."
-                                                                                                   End Sub)
-                                                                                        Catch ex As Exception
-                                                                                        End Try
-                                                                                    End Sub
+                                                     Dim subRoutine As New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                             Try
+                                                                                                                 Invoke(Sub()
+                                                                                                                            percentage = If(totalBytesRead <> 0 And size <> 0, totalBytesRead / size * 100, 0)
+                                                                                                                            ProgressBar.Value = percentage
+                                                                                                                            lblStatus.Text = $"{strFileNameLine}{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({Math.Round(percentage, byteRoundPercentages)}%) have been processed with a {intBufferSize} MB buffer size."
+                                                                                                                        End Sub)
+                                                                                                             Catch ex As Exception
+                                                                                                             End Try
+                                                                                                         End Sub)
 
                                                      Dim stopWatch As Stopwatch = Stopwatch.StartNew
                                                      Dim computeStopwatch As Stopwatch

--- a/Hasher/Form1.Designer.vb
+++ b/Hasher/Form1.Designer.vb
@@ -1538,7 +1538,7 @@ Partial Class Form1
         Me.chkShowFileProgressInFileList.Size = New System.Drawing.Size(165, 17)
         Me.chkShowFileProgressInFileList.TabIndex = 42
         Me.chkShowFileProgressInFileList.Text = "Show File Progress in File List"
-        Me.ToolTip.SetToolTip(Me.chkShowFileProgressInFileList, "Enables the option to show the progress of reading a file in the file list.")
+        Me.ToolTip.SetToolTip(Me.chkShowFileProgressInFileList, "Enables the option to show the progress of reading a file in the file list." & vbCrLf & "Looks pretty but will cause performance degradations.")
         Me.chkShowFileProgressInFileList.UseVisualStyleBackColor = True
         '
         'defaultHashType

--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -1434,6 +1434,11 @@ Public Class Form1
 
                                                      longTotalFiles = verifyHashesListFiles.Rows.Count
 
+                                                     MyInvoke(Sub()
+                                                                  verifyHashesListFiles.BeginEdit(True)
+                                                                  verifyHashesListFiles.SuspendLayout()
+                                                              End Sub, verifyHashesListFiles)
+
                                                      For Each item As MyDataGridViewRow In verifyHashesListFiles.Rows
                                                          If boolAbortThread Then Throw New MyThreadAbortException
                                                          currentItem = item
@@ -1510,6 +1515,11 @@ Public Class Form1
                                                              item.BoolValidHash = False
                                                          End If
                                                      Next
+
+                                                     MyInvoke(Sub()
+                                                                  verifyHashesListFiles.EndEdit()
+                                                                  verifyHashesListFiles.ResumeLayout()
+                                                              End Sub, verifyHashesListFiles)
 
                                                      GC.Collect()
 

--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -423,25 +423,25 @@ Public Class Form1
                                                                  computeStopwatch = Stopwatch.StartNew
 
                                                                  If DoChecksumWithAttachedSubRoutine(myItem.FileName, allTheHashes, subRoutine, exceptionObject) Then
-                                                                     Invoke(Sub()
-                                                                                myItem.AllTheHashes = allTheHashes
-                                                                                strChecksum = GetDataFromAllTheHashes(checksumType, allTheHashes)
-                                                                                myItem.Cells(2).Value = If(chkDisplayHashesInUpperCase.Checked, strChecksum.ToUpper, strChecksum.ToLower)
-                                                                                myItem.ComputeTime = computeStopwatch.Elapsed
-                                                                                myItem.Cells(3).Value = TimespanToHMS(myItem.ComputeTime)
-                                                                                myItem.Hash = strChecksum
-                                                                                myItem.BoolExceptionOccurred = False
-                                                                                myItem.StrCrashData = Nothing
-                                                                            End Sub, listFiles)
+                                                                     MyInvoke(Sub()
+                                                                                  myItem.AllTheHashes = allTheHashes
+                                                                                  strChecksum = GetDataFromAllTheHashes(checksumType, allTheHashes)
+                                                                                  myItem.Cells(2).Value = If(chkDisplayHashesInUpperCase.Checked, strChecksum.ToUpper, strChecksum.ToLower)
+                                                                                  myItem.ComputeTime = computeStopwatch.Elapsed
+                                                                                  myItem.Cells(3).Value = TimespanToHMS(myItem.ComputeTime)
+                                                                                  myItem.Hash = strChecksum
+                                                                                  myItem.BoolExceptionOccurred = False
+                                                                                  myItem.StrCrashData = Nothing
+                                                                              End Sub, listFiles)
                                                                  Else
-                                                                     Invoke(Sub()
-                                                                                myItem.Cells(2).Value = If(exceptionObject.GetType IsNot Nothing, $"(An error occurred while calculating checksum, {exceptionObject.GetType})", "(An error occurred while calculating checksum, unknown exception type)")
-                                                                                myItem.Cells(3).Value = ""
-                                                                                myItem.ComputeTime = Nothing
-                                                                                myItem.BoolExceptionOccurred = True
-                                                                                myItem.StrCrashData = $"{exceptionObject.Message}{vbCrLf}{exceptionObject.StackTrace}"
-                                                                                longErroredFiles += 1
-                                                                            End Sub, listFiles)
+                                                                     MyInvoke(Sub()
+                                                                                  myItem.Cells(2).Value = If(exceptionObject.GetType IsNot Nothing, $"(An error occurred while calculating checksum, {exceptionObject.GetType})", "(An error occurred while calculating checksum, unknown exception type)")
+                                                                                  myItem.Cells(3).Value = ""
+                                                                                  myItem.ComputeTime = Nothing
+                                                                                  myItem.BoolExceptionOccurred = True
+                                                                                  myItem.StrCrashData = $"{exceptionObject.Message}{vbCrLf}{exceptionObject.StackTrace}"
+                                                                                  longErroredFiles += 1
+                                                                              End Sub, listFiles)
                                                                  End If
 
                                                                  MyInvoke(Sub()

--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -122,7 +122,7 @@ Public Class Form1
         Return If(chkUseCommasInNumbers.Checked, input.ToString("N0"), input.ToString)
     End Function
 
-    Private Function DoChecksumWithAttachedSubRoutine(strFile As String, ByRef allTheHashes As AllTheHashes, subRoutine As [Delegate], ByRef exceptionObject As Exception) As Boolean
+    Private Function DoChecksumWithAttachedSubRoutine(strFile As String, ByRef allTheHashes As AllTheHashes, subRoutine As ChecksumStatusUpdaterDelegate, ByRef exceptionObject As Exception) As Boolean
         Try
             If IO.File.Exists(strFile) Then
                 Dim checksums As New Checksums(subRoutine)
@@ -337,30 +337,30 @@ Public Class Form1
                                                          longAllBytes = 0
                                                      End SyncLock
 
-                                                     Dim subRoutine As [Delegate] = Sub(size As Long, totalBytesRead As Long)
-                                                                                        Try
-                                                                                            MyInvoke(Sub()
-                                                                                                         percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
-                                                                                                         IndividualFilesProgressBar.Value = percentage
+                                                     Dim subRoutine As New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                             Try
+                                                                                                                 MyInvoke(Sub()
+                                                                                                                              percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
+                                                                                                                              IndividualFilesProgressBar.Value = percentage
 
-                                                                                                         SyncLock threadLockingObject
-                                                                                                             allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
-                                                                                                             lblHashIndividualFilesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
-                                                                                                             If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
-                                                                                                         End SyncLock
+                                                                                                                              SyncLock threadLockingObject
+                                                                                                                                  allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
+                                                                                                                                  lblHashIndividualFilesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                                  If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
+                                                                                                                              End SyncLock
 
-                                                                                                         ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
-                                                                                                         hashIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
-                                                                                                         lblIndividualFilesStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                              ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
+                                                                                                                              hashIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
+                                                                                                                              lblIndividualFilesStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
 
-                                                                                                         If chkShowFileProgressInFileList.Checked Then
-                                                                                                             currentItem.Cells(2).Value = lblIndividualFilesStatus.Text
-                                                                                                             itemOnGUI.Cells(2).Value = currentItem.Cells(2).Value
-                                                                                                         End If
-                                                                                                     End Sub)
-                                                                                        Catch ex As Exception
-                                                                                        End Try
-                                                                                    End Sub
+                                                                                                                              If chkShowFileProgressInFileList.Checked Then
+                                                                                                                                  currentItem.Cells(2).Value = lblIndividualFilesStatus.Text
+                                                                                                                                  itemOnGUI.Cells(2).Value = currentItem.Cells(2).Value
+                                                                                                                              End If
+                                                                                                                          End Sub)
+                                                                                                             Catch ex As Exception
+                                                                                                             End Try
+                                                                                                         End Sub)
 
                                                      MyInvoke(Sub()
                                                                   radioMD5.Enabled = False
@@ -1400,27 +1400,27 @@ Public Class Form1
                                                      Dim fileCountPercentage As Double
                                                      Dim exceptionObject As Exception = Nothing
 
-                                                     Dim subRoutine As [Delegate] = Sub(size As Long, totalBytesRead As Long)
-                                                                                        Try
-                                                                                            MyInvoke(Sub()
-                                                                                                         percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
-                                                                                                         VerifyHashProgressBar.Value = percentage
-                                                                                                         SyncLock threadLockingObject
-                                                                                                             allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
-                                                                                                             lblVerifyHashesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
-                                                                                                             If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
-                                                                                                         End SyncLock
-                                                                                                         lblProcessingFileVerify.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
-                                                                                                         If chkShowFileProgressInFileList.Checked Then
-                                                                                                             currentItem.Cells(4).Value = lblProcessingFileVerify.Text
-                                                                                                             itemOnGUI.Cells(4).Value = currentItem.Cells(4).Value
-                                                                                                         End If
-                                                                                                         ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
-                                                                                                         verifyIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
-                                                                                                     End Sub)
-                                                                                        Catch ex As Exception
-                                                                                        End Try
-                                                                                    End Sub
+                                                     Dim subRoutine As New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                             Try
+                                                                                                                 MyInvoke(Sub()
+                                                                                                                              percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
+                                                                                                                              VerifyHashProgressBar.Value = percentage
+                                                                                                                              SyncLock threadLockingObject
+                                                                                                                                  allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
+                                                                                                                                  lblVerifyHashesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                                  If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
+                                                                                                                              End SyncLock
+                                                                                                                              lblProcessingFileVerify.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                              If chkShowFileProgressInFileList.Checked Then
+                                                                                                                                  currentItem.Cells(4).Value = lblProcessingFileVerify.Text
+                                                                                                                                  itemOnGUI.Cells(4).Value = currentItem.Cells(4).Value
+                                                                                                                              End If
+                                                                                                                              ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
+                                                                                                                              verifyIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
+                                                                                                                          End Sub)
+                                                                                                             Catch ex As Exception
+                                                                                                             End Try
+                                                                                                         End Sub)
 
                                                      longTotalFiles = verifyHashesListFiles.Rows.Count
 
@@ -1892,23 +1892,23 @@ Public Class Form1
                                                      Dim exceptionObject1 As Exception = Nothing
                                                      Dim exceptionObject2 As Exception = Nothing
 
-                                                     Dim subRoutine As [Delegate] = Sub(size As Long, totalBytesRead As Long)
-                                                                                        Try
-                                                                                            MyInvoke(Sub()
-                                                                                                         percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
-                                                                                                         compareFilesProgressBar.Value = percentage
-                                                                                                         SyncLock threadLockingObject
-                                                                                                             allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
-                                                                                                         End SyncLock
-                                                                                                         ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
-                                                                                                         CompareFilesAllFilesProgress.Value = allBytesPercentage
-                                                                                                         lblCompareFilesStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
-                                                                                                         lblCompareFilesAllFilesStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
-                                                                                                         If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
-                                                                                                     End Sub)
-                                                                                        Catch ex As Exception
-                                                                                        End Try
-                                                                                    End Sub
+                                                     Dim subRoutine As New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                             Try
+                                                                                                                 MyInvoke(Sub()
+                                                                                                                              percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
+                                                                                                                              compareFilesProgressBar.Value = percentage
+                                                                                                                              SyncLock threadLockingObject
+                                                                                                                                  allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
+                                                                                                                              End SyncLock
+                                                                                                                              ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
+                                                                                                                              CompareFilesAllFilesProgress.Value = allBytesPercentage
+                                                                                                                              lblCompareFilesStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                              lblCompareFilesAllFilesStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                              If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
+                                                                                                                          End Sub)
+                                                                                                             Catch ex As Exception
+                                                                                                             End Try
+                                                                                                         End Sub)
 
                                                      Dim myStopWatch As Stopwatch = Stopwatch.StartNew
 
@@ -2156,18 +2156,18 @@ Public Class Form1
 
                                                      Dim strChecksum As String = Nothing
                                                      Dim percentage As Double
-                                                     Dim subRoutine As [Delegate] = Sub(size As Long, totalBytesRead As Long)
-                                                                                        Try
-                                                                                            MyInvoke(Sub()
-                                                                                                         percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
-                                                                                                         compareAgainstKnownHashProgressBar.Value = percentage
-                                                                                                         ProgressForm.SetTaskbarProgressBarValue(compareAgainstKnownHashProgressBar.Value)
-                                                                                                         lblCompareAgainstKnownHashStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
-                                                                                                         If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(percentage, byteRoundPercentages)}% Completed)"
-                                                                                                     End Sub)
-                                                                                        Catch ex As Exception
-                                                                                        End Try
-                                                                                    End Sub
+                                                     Dim subRoutine As New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                             Try
+                                                                                                                 MyInvoke(Sub()
+                                                                                                                              percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
+                                                                                                                              compareAgainstKnownHashProgressBar.Value = percentage
+                                                                                                                              ProgressForm.SetTaskbarProgressBarValue(compareAgainstKnownHashProgressBar.Value)
+                                                                                                                              lblCompareAgainstKnownHashStatus.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                              If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(percentage, byteRoundPercentages)}% Completed)"
+                                                                                                                          End Sub)
+                                                                                                             Catch ex As Exception
+                                                                                                             End Try
+                                                                                                         End Sub)
 
                                                      Dim myStopWatch As Stopwatch = Stopwatch.StartNew
                                                      Dim allTheHashes As AllTheHashes = Nothing
@@ -2873,7 +2873,7 @@ Public Class Form1
 
                                                      Dim strChecksumInFile As String = Nothing
                                                      Dim percentage, allBytesPercentage As Double
-                                                     Dim subRoutine As [Delegate]
+                                                     Dim subRoutine As ChecksumStatusUpdaterDelegate
                                                      Dim computeStopwatch As Stopwatch
                                                      Dim allTheHashes As AllTheHashes = Nothing
                                                      Dim strDisplayValidChecksumString As String = If(chkDisplayValidChecksumString.Checked, "Valid Checksum", "")
@@ -2918,27 +2918,27 @@ Public Class Form1
                                                              strFileName = item.FileName
 
                                                              If IO.File.Exists(strFileName) Then
-                                                                 subRoutine = Sub(size As Long, totalBytesRead As Long)
-                                                                                  Try
-                                                                                      MyInvoke(Sub()
-                                                                                                   percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
-                                                                                                   VerifyHashProgressBar.Value = percentage
-                                                                                                   SyncLock threadLockingObject
-                                                                                                       allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
-                                                                                                       lblVerifyHashesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
-                                                                                                       If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
-                                                                                                   End SyncLock
-                                                                                                   lblProcessingFileVerify.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
-                                                                                                   If chkShowFileProgressInFileList.Checked Then
-                                                                                                       currentItem.Cells(4).Value = lblProcessingFileVerify.Text
-                                                                                                       itemOnGUI.Cells(4).Value = currentItem.Cells(4).Value
-                                                                                                   End If
-                                                                                                   ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
-                                                                                                   verifyIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
-                                                                                               End Sub)
-                                                                                  Catch ex As Exception
-                                                                                  End Try
-                                                                              End Sub
+                                                                 subRoutine = New ChecksumStatusUpdaterDelegate(Sub(size As Long, totalBytesRead As Long)
+                                                                                                                    Try
+                                                                                                                        MyInvoke(Sub()
+                                                                                                                                     percentage = If(totalBytesRead = 0 Or size = 0, 0, totalBytesRead / size * 100) ' This fixes a possible divide by zero exception.
+                                                                                                                                     VerifyHashProgressBar.Value = percentage
+                                                                                                                                     SyncLock threadLockingObject
+                                                                                                                                         allBytesPercentage = If(longAllReadBytes = 0 Or longAllBytes = 0, 100, longAllReadBytes / longAllBytes * 100)
+                                                                                                                                         lblVerifyHashesTotalStatus.Text = $"{FileSizeToHumanSize(longAllReadBytes)} of {FileSizeToHumanSize(longAllBytes)} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                                         If chkShowPercentageInWindowTitleBar.Checked Then Text = $"{strWindowTitle} ({MyRoundingFunction(allBytesPercentage, byteRoundPercentages)}% Completed)"
+                                                                                                                                     End SyncLock
+                                                                                                                                     lblProcessingFileVerify.Text = $"{FileSizeToHumanSize(totalBytesRead)} of {FileSizeToHumanSize(size)} ({MyRoundingFunction(percentage, byteRoundPercentages)}%) has been processed."
+                                                                                                                                     If chkShowFileProgressInFileList.Checked Then
+                                                                                                                                         currentItem.Cells(4).Value = lblProcessingFileVerify.Text
+                                                                                                                                         itemOnGUI.Cells(4).Value = currentItem.Cells(4).Value
+                                                                                                                                     End If
+                                                                                                                                     ProgressForm.SetTaskbarProgressBarValue(allBytesPercentage)
+                                                                                                                                     verifyIndividualFilesAllFilesProgressBar.Value = allBytesPercentage
+                                                                                                                                 End Sub)
+                                                                                                                    Catch ex As Exception
+                                                                                                                    End Try
+                                                                                                                End Sub)
 
                                                                  item.Cells(3).Value = strCurrentlyBeingProcessed
 

--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -1,4 +1,5 @@
-﻿Imports System.ComponentModel
+﻿Imports System.Buffers
+Imports System.ComponentModel
 Imports System.IO.Pipes
 Imports System.Reflection
 Imports System.Security.Cryptography
@@ -12,6 +13,8 @@ Public Class Form1
 #Else
     Private Const strWindowTitle As String = "Hasher"
 #End If
+
+    Private pool As ArrayPool(Of Byte) = ArrayPool(Of Byte).Shared
 
     Private Const strMessageBoxTitleText As String = "Hasher"
     Private intBufferSize As Integer = My.Settings.shortBufferSize * 1024 * 1024
@@ -125,7 +128,7 @@ Public Class Form1
     Private Function DoChecksumWithAttachedSubRoutine(strFile As String, ByRef allTheHashes As AllTheHashes, subRoutine As ChecksumStatusUpdaterDelegate, ByRef exceptionObject As Exception) As Boolean
         Try
             If IO.File.Exists(strFile) Then
-                Dim checksums As New Checksums(subRoutine)
+                Dim checksums As New Checksums(subRoutine, pool)
                 allTheHashes = checksums.PerformFileHash(strFile, intBufferSize)
                 Return True
             Else

--- a/Hasher/Hasher.vbproj
+++ b/Hasher/Hasher.vbproj
@@ -218,6 +218,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
+    <PackageReference Include="System.Buffers">
+      <Version>4.6.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
 </Project>

--- a/Hasher/My Project/AssemblyInfo.vb
+++ b/Hasher/My Project/AssemblyInfo.vb
@@ -31,4 +31,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("8.1.1.29")>
+<Assembly: AssemblyFileVersion("8.1.2.30")>

--- a/Hasher/Program Modules/HTTPHelper.vb
+++ b/Hasher/Program Modules/HTTPHelper.vb
@@ -1,6 +1,5 @@
 ﻿Imports System.IO
 Imports System.Security.Cryptography
-Imports System.Runtime.CompilerServices
 
 Public Class FormFile
 
@@ -200,9 +199,13 @@ Class Credentials
     Public Property StrPasswordInput As String
 End Class
 
+' Strongly typed delegates
+Public Delegate Sub DownloadStatusUpdaterDelegate(downloadStatusDetails As DownloadStatusDetails)
+Public Delegate Sub CustomErrorHandlerDelegate(ex As Exception, thisInstance As HttpHelper)
+
 ''' <summary>Allows you to easily POST and upload files to a remote HTTP server without you, the programmer, knowing anything about how it all works. This class does it all for you. It handles adding a User Agent String, additional HTTP Request Headers, string data to your HTTP POST data, and files to be uploaded in the HTTP POST data.</summary>
 Public Class HttpHelper
-    Private Const classVersion As String = "1.345"
+    Private Const classVersion As String = "1.347"
 
     Private strUserAgentString As String = Nothing
     Private boolUseProxy As Boolean = False
@@ -229,11 +232,11 @@ Public Class HttpHelper
 
     Private sslCertificate As X509Certificates.X509Certificate2
     Private urlPreProcessor As Func(Of String, String)
-    Private customErrorHandler As [Delegate]
 
     Private Const strCRLF As String = vbCrLf
 
-    Private downloadStatusUpdater As [Delegate]
+    Private downloadStatusUpdater As DownloadStatusUpdaterDelegate
+    Private customErrorHandler As CustomErrorHandlerDelegate
 
     Public Structure RemoteFileStats
         Public contentLength As Long
@@ -265,8 +268,8 @@ Public Class HttpHelper
     ''' OR A C# Example...
     ''' httpHelper.setCustomErrorHandler((Exception ex, httpHelper classInstance) => { }
     ''' </example>
-    Public WriteOnly Property SetCustomErrorHandler As [Delegate]
-        Set(value As [Delegate])
+    Public WriteOnly Property SetCustomErrorHandler As CustomErrorHandlerDelegate
+        Set(value As CustomErrorHandlerDelegate)
             customErrorHandler = value
         End Set
     End Property
@@ -354,8 +357,8 @@ Public Class HttpHelper
     ''' OR A C# Example...
     ''' httpHelper.setDownloadStatusUpdateRoutine((downloadStatusDetails downloadStatusDetails) => { })
     ''' </example>
-    Public WriteOnly Property SetDownloadStatusUpdateRoutine As [Delegate]
-        Set(value As [Delegate])
+    Public WriteOnly Property SetDownloadStatusUpdateRoutine As DownloadStatusUpdaterDelegate
+        Set(value As DownloadStatusUpdaterDelegate)
             downloadStatusUpdater = value
         End Set
     End Property
@@ -779,7 +782,7 @@ Public Class HttpHelper
     Private Sub DownloadStatusUpdaterThreadSubroutine()
         Try
 beginAgain:
-            downloadStatusUpdater.DynamicInvoke(downloadStatusDetails)
+            downloadStatusUpdater(downloadStatusDetails)
             Threading.Thread.Sleep(_intDownloadThreadSleepTime)
             GoTo beginAgain
         Catch ex As Threading.ThreadAbortException
@@ -807,7 +810,7 @@ beginAgain:
                     downloadStatusUpdaterThread.Start()
                 End If
             Else
-                downloadStatusUpdater.DynamicInvoke(downloadStatusDetails)
+                downloadStatusUpdater(downloadStatusDetails)
             End If
         End If
     End Sub
@@ -866,7 +869,7 @@ beginAgain:
             If Not throwExceptionIfError Then Return False
 
             If customErrorHandler IsNot Nothing Then
-                customErrorHandler.DynamicInvoke(ex, Me)
+                customErrorHandler(ex, Me)
                 ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                 Return False
             End If
@@ -966,7 +969,7 @@ beginAgain:
             If Not throwExceptionIfError Then Return False
 
             If customErrorHandler IsNot Nothing Then
-                customErrorHandler.DynamicInvoke(ex, Me)
+                customErrorHandler(ex, Me)
                 ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                 Return False
             End If
@@ -1075,7 +1078,7 @@ beginAgain:
                 If Not throwExceptionIfError Then Return False
 
                 If customErrorHandler IsNot Nothing Then
-                    customErrorHandler.DynamicInvoke(ex, Me)
+                    customErrorHandler(ex, Me)
                     ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                     Return False
                 End If
@@ -1154,7 +1157,7 @@ beginAgain:
             If Not throwExceptionIfError Then Return False
 
             If customErrorHandler IsNot Nothing Then
-                customErrorHandler.DynamicInvoke(ex, Me)
+                customErrorHandler(ex, Me)
                 ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                 Return False
             End If
@@ -1230,7 +1233,7 @@ beginAgain:
             If Not throwExceptionIfError Then Return False
 
             If customErrorHandler IsNot Nothing Then
-                customErrorHandler.DynamicInvoke(ex, Me)
+                customErrorHandler(ex, Me)
                 ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                 Return False
             End If
@@ -1355,7 +1358,7 @@ beginAgain:
             If Not throwExceptionIfError Then Return False
 
             If customErrorHandler IsNot Nothing Then
-                customErrorHandler.DynamicInvoke(ex, Me)
+                customErrorHandler(ex, Me)
                 ' Since we handled the exception with an injected custom error handler, we can now exit the function with the return of a False value.
                 Return False
             End If

--- a/Hasher/Program Modules/checksums.vb
+++ b/Hasher/Program Modules/checksums.vb
@@ -1,17 +1,19 @@
 Imports System.Security.Cryptography
 
 Public Class Checksums
-    Private ReadOnly checksumStatusUpdater As [Delegate]
+    Private ReadOnly checksumStatusUpdater As ChecksumStatusUpdaterDelegate
 
-    ''' <summary>This allows you to set up a function to be run while your checksum is being processed. This function can be used to update things on the GUI during a checksum.</summary>
+    ''' <summary>
+    ''' This allows you to set up a function to be run while your checksum is being processed. This function can be used to update things on the GUI during a checksum.
+    ''' </summary>
     ''' <example>
     ''' A VB.NET Example...
-    ''' Dim checksums As New checksum(Function(ByVal checksumStatusDetails As checksumStatusDetails)
-    ''' End Function)
+    ''' Dim checksums As New Checksums(Sub(ByVal checksumStatusDetails As checksumStatusDetails)
+    ''' End Sub)
     ''' OR A C# Example...
-    ''' checksum checksums = new checksum((checksumStatusDetails checksumStatusDetails) => { });
+    ''' Checksums checksums = new Checksums((checksumStatusDetails checksumStatusDetails) => { });
     ''' </example>
-    Public Sub New(ByRef inputDelegate As [Delegate])
+    Public Sub New(inputDelegate As ChecksumStatusUpdaterDelegate)
         checksumStatusUpdater = inputDelegate
     End Sub
 
@@ -48,8 +50,8 @@ Public Class Checksums
                         longAllReadBytes += intBytesRead
                     End SyncLock
 
-                    ' Call the status updating delegate
-                    checksumStatusUpdater.DynamicInvoke(longFileSize, longTotalBytesRead)
+                    ' Directly invoke the delegate
+                    checksumStatusUpdater(longFileSize, longTotalBytesRead)
 
                     ' Check for thread abort
                     If boolAbortThread Then Throw New MyThreadAbortException()
@@ -82,3 +84,6 @@ Public Structure AllTheHashes
     Public Property Sha384 As String
     Public Property Sha512 As String
 End Structure
+
+' Strongly typed delegate
+Public Delegate Sub ChecksumStatusUpdaterDelegate(fileSize As Long, bytesRead As Long)

--- a/Hasher/Program Modules/checksums.vb
+++ b/Hasher/Program Modules/checksums.vb
@@ -48,10 +48,8 @@ Public Class Checksums
                     sha512Engine.TransformBlock(byteDataBuffer, 0, intBytesRead, byteDataBuffer, 0)
 
                     ' Update progress
-                    longTotalBytesRead += intBytesRead
-                    SyncLock threadLockingObject
-                        longAllReadBytes += intBytesRead
-                    End SyncLock
+                    Threading.Interlocked.Add(longTotalBytesRead, intBytesRead)
+                    Threading.Interlocked.Add(longAllReadBytes, intBytesRead)
 
                     ' Directly invoke the delegate
                     checksumStatusUpdater(longFileSize, longTotalBytesRead)


### PR DESCRIPTION
- Converted the delegates used in the checksum code to strongly typed delegates for faster performance.
- Changed the code of the MyInvoke() function so that we can direct what control upon which we want to invoke the passed delegate.
- Added some code to hopefully improve performance.
- Added an indication in the tooltip that enabling "Show File Progress In File List" could cause performance degradation.
- Fixed a crash when computing the hash of a file.
- Updated the HTTPHelper class to version 1.347.
- The data byte buffer used to hold data during checksum calculations is now using Array Pools.
- Made the edition of the two numbers thread safe.
- Added support for hash files that have no file name embedded in the hash file.