### PR TITLE
Version 8.5 Build 6

### DIFF
--- a/Hasher/Form1.vb
+++ b/Hasher/Form1.vb
@@ -667,7 +667,7 @@ Public Class Form1
                                 SaveFileDialog.FileName &= ".sha256"
                             Case "SHA384 File|*.sha384"
                                 SaveFileDialog.FileName &= ".sha384"
-                            Case "SHA384 File|*.sha512"
+                            Case "SHA512 File|*.sha512"
                                 SaveFileDialog.FileName &= ".sha512"
                         End Select
                     End If

--- a/Hasher/My Project/AssemblyInfo.vb
+++ b/Hasher/My Project/AssemblyInfo.vb
@@ -31,4 +31,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("8.5.5.41")>
+<Assembly: AssemblyFileVersion("8.5.6.42")>


### PR DESCRIPTION
This is an emergency fix for a potential data loss issue due to a logic error in the code.

Fixed a bug involving saving SHA512 files to disk that could result in data loss if the user attempts to save a checksum file with the same name as the file that they're creating a checksum for. d36fc5e86ddfbcf75572197cb1aeb5ebc3b2dd29